### PR TITLE
fix:修復課程教室的讀取函數問題，順便更新了課程資料

### DIFF
--- a/frontend/src/components/1_CoursePlanner/CoursePlanner.jsx
+++ b/frontend/src/components/1_CoursePlanner/CoursePlanner.jsx
@@ -193,7 +193,7 @@ const CoursePlanner = () => {
     if (course.department) info.push(course.department);
     if (course.division) info.push(course.division);
     if (course.time) info.push(course.time);
-    if (course.classroom && course.classroom.trim() !== '') info.push(course.classroom);
+    if (course.location && course.location.trim() !== '') info.push(course.location);
     if (course.course_credit) info.push(`${course.course_credit}學分`);
     
     return info.join(' | ');

--- a/frontend/src/components/1_CoursePlanner/CourseTable.jsx
+++ b/frontend/src/components/1_CoursePlanner/CourseTable.jsx
@@ -240,11 +240,11 @@ const CourseTable = ({ schedule, onRemove }) => {
           key={`${day}-${period}`} 
           className="course-cell-filled"
           onClick={() => onRemove && onRemove(course.course_id, course.time)}
-          title={`課程：${course.course_cname}\n教師：${course.teacher}\n教室：${course.classroom}\n學分：${course.course_credit}`}
+          title={`課程：${course.course_cname}\n教師：${course.teacher}\n教室：${course.location}\n學分：${course.course_credit}`}
         >
           <div className="course-name">{course.course_cname}</div>
           <div className="course-teacher">{course.teacher}</div>
-          <div className="course-room">{course.classroom}</div>
+          <div className="course-room">{course.location}</div>
         </td>
       );
     }

--- a/frontend/src/components/5_UpdateLog/updateData.js
+++ b/frontend/src/components/5_UpdateLog/updateData.js
@@ -2,6 +2,17 @@
 
 export const updateHistory = [
   {
+    version: "v4.0.1",
+    date: "2025-08-10",
+    type: "fix", 
+    title: "修復課程資料顯示",
+    description: "修復「智慧選課」課程教室位置沒有顯示出來的問題",
+    features: [
+      "🔧 修復「智慧選課」分頁的課程教室資訊的class-room讀取函數，將course.classroom改為course.location",
+      "📚 順便再次更新了本學期開課資料，課程總數從1456更新至1469門課程",
+    ]
+  },
+  {
     version: "v4.0.0",
     date: "2025-08-03",
     type: "major", 
@@ -23,7 +34,7 @@ export const updateHistory = [
       "新增響應式滾動條樣式，提升跨裝置一致性",
       "修復多處UI細節問題，提升整體使用體驗",
     ]
-},
+  },
   {
     version: "v3.2.0",
     date: "2025-07-25",


### PR DESCRIPTION
修復課程資料顯示
修復「智慧選課」課程教室位置沒有顯示出來的問題

🎯 本次更新內容：
🔧 修復「智慧選課」分頁的課程教室資訊的class-room讀取函數，將course.classroom改為course.location
📚 順便再次更新了本學期開課資料，課程總數從1456更新至1469門課程